### PR TITLE
Add AI-slop detection with metrics and UI

### DIFF
--- a/locales/actions.yml
+++ b/locales/actions.yml
@@ -18,6 +18,7 @@ actions.stats:
     🔍 Analyzed lyrics <code>%{lyrics_analyzed}</code> times
     🙈 You ignored <code>%{ignored}</code> track lyrics
     🤬 <code>%{lyrics_profane}</code> lyrics were considered profane
+    💩 <code>%{ai_slop_total}</code> tracks were detected as AI Slop
 
     <blockquote expandable><b>Languages stats:</b>
     %{languages}</blockquote>
@@ -32,6 +33,7 @@ actions.stats:
     🔍 Проанализировано текстов <code>%{lyrics_analyzed}</code> раз
     🙈 Вы проигнорировали <code>%{ignored}</code> текстов треков
     🤬 <code>%{lyrics_profane}</code> текстов были признаны нецензурными
+    💩 <code>%{ai_slop_total}</code> треков были определены как ИИ шлак
 
     <blockquote expandable><b>Статистика по языкам (названия на английском):</b>
     %{languages}</blockquote>

--- a/migrations/20260308152848_add_ai_slop_detection_counters.sql
+++ b/migrations/20260308152848_add_ai_slop_detection_counters.sql
@@ -1,0 +1,5 @@
+alter table "user"
+    add column ai_slop_spotify_ai_blocker bigint not null default 0,
+    add column ai_slop_soul_over_ai bigint not null default 0,
+    add column ai_slop_shlabs bigint not null default 0,
+    add column ai_slop_human_made bigint not null default 0;

--- a/src/entity/user.rs
+++ b/src/entity/user.rs
@@ -22,8 +22,10 @@ pub struct Model {
     pub name: String,
     pub locale: Locale,
     pub role: Role,
+
     pub removed_playlists: i64,
     pub removed_collection: i64,
+
     pub lyrics_checked: i64,
     pub lyrics_analyzed: i64,
     pub lyrics_genius: i64,
@@ -31,15 +33,27 @@ pub struct Model {
     #[sea_orm(enum_name = "LyricsLrcLib")]
     pub lyrics_lrclib: i64,
     pub lyrics_profane: i64,
+
+    #[sea_orm(enum_name = "AISlopSpotifyAIBlocker")]
+    pub ai_slop_spotify_ai_blocker: i64,
+    #[sea_orm(enum_name = "AISlopSoulOverAI")]
+    pub ai_slop_soul_over_ai: i64,
+    #[sea_orm(enum_name = "AISlopSHLabs")]
+    pub ai_slop_shlabs: i64,
+    #[sea_orm(enum_name = "AISlopHumanMade")]
+    pub ai_slop_human_made: i64,
+
     pub status: Status,
     pub created_at: chrono::NaiveDateTime,
     pub updated_at: chrono::NaiveDateTime,
+
     pub cfg_check_profanity: bool,
     pub cfg_skip_tracks: bool,
     pub cfg_skippage_secs: i64,
     pub cfg_skippage_enabled: bool,
     #[sea_orm(enum_name = "CfgAISlopDetection")]
     pub cfg_ai_slop_detection: AISlopDetection,
+
     pub magic_playlist: Option<String>,
     pub spotify_state: Uuid,
     pub ref_code: Option<String>,
@@ -70,8 +84,10 @@ pub enum Column {
     Name,
     Locale,
     Role,
+
     RemovedPlaylists,
     RemovedCollection,
+
     LyricsChecked,
     LyricsAnalyzed,
     LyricsGenius,
@@ -79,15 +95,27 @@ pub enum Column {
     #[sea_orm(column_name = "lyrics_lrclib")]
     LyricsLrcLib,
     LyricsProfane,
+
+    #[sea_orm(column_name = "ai_slop_spotify_ai_blocker")]
+    AISlopSpotifyAIBlocker,
+    #[sea_orm(column_name = "ai_slop_soul_over_ai")]
+    AISlopSoulOverAI,
+    #[sea_orm(column_name = "ai_slop_shlabs")]
+    AISlopSHLabs,
+    #[sea_orm(column_name = "ai_slop_human_made")]
+    AISlopHumanMade,
+
     Status,
     CreatedAt,
     UpdatedAt,
+
     CfgCheckProfanity,
     CfgSkipTracks,
     CfgSkippageSecs,
     CfgSkippageEnabled,
     #[sea_orm(column_name = "cfg_ai_slop_detection")]
     CfgAISlopDetection,
+
     MagicPlaylist,
     SpotifyState,
     RefCode,
@@ -115,14 +143,22 @@ impl ColumnTrait for Column {
             Self::Name => ColumnType::Text.def(),
             Self::Locale => Locale::db_type(),
             Self::Role => Role::db_type(),
+
             Self::RemovedPlaylists => ColumnType::BigInteger.def(),
             Self::RemovedCollection => ColumnType::BigInteger.def(),
+
             Self::LyricsChecked => ColumnType::BigInteger.def(),
             Self::LyricsAnalyzed => ColumnType::BigInteger.def(),
             Self::LyricsGenius => ColumnType::BigInteger.def(),
             Self::LyricsMusixmatch => ColumnType::BigInteger.def(),
             Self::LyricsLrcLib => ColumnType::BigInteger.def(),
             Self::LyricsProfane => ColumnType::BigInteger.def(),
+
+            Self::AISlopSpotifyAIBlocker => ColumnType::BigInteger.def(),
+            Self::AISlopSoulOverAI => ColumnType::BigInteger.def(),
+            Self::AISlopSHLabs => ColumnType::BigInteger.def(),
+            Self::AISlopHumanMade => ColumnType::BigInteger.def(),
+
             Self::Status => Status::db_type(),
             Self::CreatedAt => ColumnType::DateTime.def(),
             Self::UpdatedAt => ColumnType::DateTime.def(),

--- a/src/metrics/influx_collector.rs
+++ b/src/metrics/influx_collector.rs
@@ -82,6 +82,15 @@ struct TrackLanguageStats {
 }
 
 #[derive(InfluxDbWriteable, Debug)]
+struct AISlopDetectionStats {
+    time: Timestamp,
+    spotify_ai_blocker: u64,
+    soul_over_ai: u64,
+    shlabs: u64,
+    human_made: u64,
+}
+
+#[derive(InfluxDbWriteable, Debug)]
 struct Uptime {
     time: Timestamp,
     secs_elapsed: u64,
@@ -113,6 +122,10 @@ pub async fn collect(client: &InfluxClient, app: &App) -> anyhow::Result<()> {
         lyrics_musixmatch,
         lyrics_lrclib,
         lyrics_analyzed,
+        ai_slop_spotify_ai_blocker,
+        ai_slop_soul_over_ai,
+        ai_slop_shlabs,
+        ai_slop_human_made,
     } = UserService::get_stats(app.db(), None).await?;
 
     let tick_health_status = utils::tick_health().await;
@@ -154,6 +167,14 @@ pub async fn collect(client: &InfluxClient, app: &App) -> anyhow::Result<()> {
             spotify_429: MetricsService::spotify_429_get(&mut redis_conn).await?,
         }
         .into_query("errors"),
+        AISlopDetectionStats {
+            time,
+            spotify_ai_blocker: ai_slop_spotify_ai_blocker as u64,
+            soul_over_ai: ai_slop_soul_over_ai as u64,
+            shlabs: ai_slop_shlabs as u64,
+            human_made: ai_slop_human_made as u64,
+        }
+        .into_query("ai_slop_detection"),
         Uptime::new(time).into_query("uptime"),
     ];
 

--- a/src/metrics/prometheus.rs
+++ b/src/metrics/prometheus.rs
@@ -118,7 +118,7 @@ impl PrometheusClient {
                 &["provider"],
                 registry
             )
-            .context("Failed to register lyrics_source metric")?,
+            .context("Failed to register ai_slop_detection metric")?,
 
             process_duration: register_histogram_with_registry!(
                 "process_duration_seconds",

--- a/src/metrics/prometheus.rs
+++ b/src/metrics/prometheus.rs
@@ -33,6 +33,7 @@ pub struct PrometheusMetrics {
     pub lyrics_found: IntGauge,
     pub lyrics_profane: IntGauge,
     pub lyrics_source: IntGaugeVec,
+    pub ai_slop_detection: IntGaugeVec,
     pub process_duration: Histogram,
     pub process_check_interval_seconds: Gauge,
     pub process_users_checked: IntCounter,
@@ -107,6 +108,14 @@ impl PrometheusClient {
                 "lyrics_source_total",
                 "Lyrics by source",
                 &["source"],
+                registry
+            )
+            .context("Failed to register lyrics_source metric")?,
+
+            ai_slop_detection: register_int_gauge_vec_with_registry!(
+                "ai_slop_detection_total",
+                "AI Detection Providers",
+                &["provider"],
                 registry
             )
             .context("Failed to register lyrics_source metric")?,

--- a/src/metrics/prometheus_collector.rs
+++ b/src/metrics/prometheus_collector.rs
@@ -34,6 +34,10 @@ pub async fn collect(client: &PrometheusClient, app: &App) -> anyhow::Result<()>
         lyrics_musixmatch,
         lyrics_lrclib,
         lyrics_analyzed,
+        ai_slop_spotify_ai_blocker,
+        ai_slop_soul_over_ai,
+        ai_slop_shlabs,
+        ai_slop_human_made,
     } = UserService::get_stats(app.db(), None).await?;
 
     let tick_health_status = utils::tick_health().await;
@@ -86,6 +90,27 @@ pub async fn collect(client: &PrometheusClient, app: &App) -> anyhow::Result<()>
         .lyrics_source
         .with_label_values(&["lrclib"])
         .set(lyrics_lrclib);
+
+    client
+        .metrics()
+        .ai_slop_detection
+        .with_label_values(&["soul_over_ai"])
+        .set(ai_slop_soul_over_ai);
+    client
+        .metrics()
+        .ai_slop_detection
+        .with_label_values(&["spotify_ai_blocker"])
+        .set(ai_slop_spotify_ai_blocker);
+    client
+        .metrics()
+        .ai_slop_detection
+        .with_label_values(&["shlabs"])
+        .set(ai_slop_shlabs);
+    client
+        .metrics()
+        .ai_slop_detection
+        .with_label_values(&["human_made"])
+        .set(ai_slop_human_made);
 
     client
         .metrics()

--- a/src/queue/track_check.rs
+++ b/src/queue/track_check.rs
@@ -89,7 +89,7 @@ pub async fn consume(data: TrackCheckQueueTask, app: Data<&'static App>) -> anyh
             .context("Check lyrics failed")?;
 
         UserService::increase_stats_query(user_state.user_id())
-            .checked_lyrics(res.profane, res.provider)
+            .checked_lyrics(res.profane, res.provider.as_ref())
             .exec(app.db())
             .await?;
 
@@ -274,6 +274,11 @@ pub async fn check_ai_slop(
     let ai_detection_result = app
         .ai_slop_detection()
         .is_track_ai(&mut app.redis_conn().await?, track)
+        .await?;
+
+    UserService::increase_stats_query(state.user_id())
+        .ai_slop(ai_detection_result.provider.as_ref())
+        .exec(app.db())
         .await?;
 
     if !ai_detection_result.prediction.is_track_ai() {

--- a/src/queue/track_check.rs
+++ b/src/queue/track_check.rs
@@ -276,10 +276,13 @@ pub async fn check_ai_slop(
         .is_track_ai(&mut app.redis_conn().await?, track)
         .await?;
 
-    UserService::increase_stats_query(state.user_id())
+    if let Err(err) = UserService::increase_stats_query(state.user_id())
         .ai_slop(ai_detection_result.provider.as_ref())
         .exec(app.db())
-        .await?;
+        .await
+    {
+        tracing::error!(error = ?err, "Failed to increase ai_slop metric");
+    }
 
     if !ai_detection_result.prediction.is_track_ai() {
         return Ok(AISlopCheckResult {

--- a/src/services/user.rs
+++ b/src/services/user.rs
@@ -15,6 +15,7 @@ use sea_orm::{
 
 use crate::entity::prelude::*;
 use crate::lyrics;
+use crate::services::ai_slop_detection;
 use crate::utils::Clock;
 
 pub struct UserStatsIncreaseQueryBuilder(UpdateMany<UserEntity>);
@@ -46,8 +47,7 @@ impl UserStatsIncreaseQueryBuilder {
         self
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn checked_lyrics(mut self, profane: bool, provider: Option<lyrics::Provider>) -> Self {
+    pub fn checked_lyrics(mut self, profane: bool, provider: Option<&lyrics::Provider>) -> Self {
         self.0 = self
             .0
             .col_expr(
@@ -64,6 +64,21 @@ impl UserStatsIncreaseQueryBuilder {
             Some(lyrics::Provider::Musixmatch) => UserColumn::LyricsMusixmatch,
             Some(lyrics::Provider::LrcLib) => UserColumn::LyricsLrcLib,
             None => return self,
+        };
+
+        self.0 = self.0.col_expr(col, Expr::col(col).add(1));
+
+        self
+    }
+
+    pub fn ai_slop(mut self, provider: Option<&ai_slop_detection::Provider>) -> Self {
+        let col = match provider {
+            Some(ai_slop_detection::Provider::SpotifyAIBlocker) => {
+                UserColumn::AISlopSpotifyAIBlocker
+            },
+            Some(ai_slop_detection::Provider::SoulOverAI) => UserColumn::AISlopSoulOverAI,
+            Some(ai_slop_detection::Provider::SHLabs) => UserColumn::AISlopSHLabs,
+            None => UserColumn::AISlopHumanMade,
         };
 
         self.0 = self.0.col_expr(col, Expr::col(col).add(1));
@@ -99,6 +114,10 @@ pub struct UserStats {
     pub lyrics_musixmatch: i64,
     pub lyrics_lrclib: i64,
     pub lyrics_analyzed: i64,
+    pub ai_slop_spotify_ai_blocker: i64,
+    pub ai_slop_soul_over_ai: i64,
+    pub ai_slop_shlabs: i64,
+    pub ai_slop_human_made: i64,
 }
 
 pub struct UserService;
@@ -478,6 +497,34 @@ impl UserService {
                     Expr::val(0).into(),
                 ]),
                 "lyrics_analyzed",
+            )
+            .expr_as(
+                Func::coalesce([
+                    UserColumn::AISlopSpotifyAIBlocker.sum().cast_as(bigint()),
+                    Expr::val(0).into(),
+                ]),
+                "ai_slop_spotify_ai_blocker",
+            )
+            .expr_as(
+                Func::coalesce([
+                    UserColumn::AISlopSoulOverAI.sum().cast_as(bigint()),
+                    Expr::val(0).into(),
+                ]),
+                "ai_slop_soul_over_ai",
+            )
+            .expr_as(
+                Func::coalesce([
+                    UserColumn::AISlopSHLabs.sum().cast_as(bigint()),
+                    Expr::val(0).into(),
+                ]),
+                "ai_slop_shlabs",
+            )
+            .expr_as(
+                Func::coalesce([
+                    UserColumn::AISlopHumanMade.sum().cast_as(bigint()),
+                    Expr::val(0).into(),
+                ]),
+                "ai_slop_human_made",
             )
             .into_model::<UserStats>()
             .one(db)

--- a/src/telegram/actions/admin_users/details.rs
+++ b/src/telegram/actions/admin_users/details.rs
@@ -118,6 +118,11 @@ async fn format_user_details(app: &'static App, user_id: &str) -> anyhow::Result
         })
         .join("\n");
 
+    let ai_slop_total = stats.ai_slop_spotify_ai_blocker
+        + stats.ai_slop_soul_over_ai
+        + stats.ai_slop_shlabs
+        + stats.ai_slop_human_made;
+
     let text = formatdoc!(
         r#"
             👤 <b>User Details</b>
@@ -157,6 +162,13 @@ async fn format_user_details(app: &'static App, user_id: &str) -> anyhow::Result
             • MusixMatch: <code>{lyrics_musixmatch}</code>
             • LrcLib: <code>{lyrics_lrclib}</code>
 
+            <b>AI Slop Detection:</b>
+            • Total <code>{ai_slop_total}</code>
+            • Soul Over AI <code>{ai_slop_soul_over_ai}</code>
+            • Spotify AI Blocker <code>{ai_slop_spotify_ai_blocker}</code>
+            • SHLabs <code>{ai_slop_shlabs}</code>
+            • Human Made <code>{ai_slop_human_made}</code>
+
             <blockquote expandable><b>Languages stats:</b>
             {languages}</blockquote>
         "#,
@@ -189,6 +201,10 @@ async fn format_user_details(app: &'static App, user_id: &str) -> anyhow::Result
         lyrics_genius = stats.lyrics_genius,
         lyrics_musixmatch = stats.lyrics_musixmatch,
         lyrics_lrclib = stats.lyrics_lrclib,
+        ai_slop_spotify_ai_blocker = stats.ai_slop_spotify_ai_blocker,
+        ai_slop_soul_over_ai = stats.ai_slop_soul_over_ai,
+        ai_slop_shlabs = stats.ai_slop_shlabs,
+        ai_slop_human_made = stats.ai_slop_human_made,
     );
 
     Ok(text)

--- a/src/telegram/actions/admin_users/details.rs
+++ b/src/telegram/actions/admin_users/details.rs
@@ -118,7 +118,7 @@ async fn format_user_details(app: &'static App, user_id: &str) -> anyhow::Result
         })
         .join("\n");
 
-    let ai_slop_total = stats.ai_slop_spotify_ai_blocker
+    let ai_slop_total_checks = stats.ai_slop_spotify_ai_blocker
         + stats.ai_slop_soul_over_ai
         + stats.ai_slop_shlabs
         + stats.ai_slop_human_made;
@@ -163,7 +163,7 @@ async fn format_user_details(app: &'static App, user_id: &str) -> anyhow::Result
             • LrcLib: <code>{lyrics_lrclib}</code>
 
             <b>AI Slop Detection:</b>
-            • Total <code>{ai_slop_total}</code>
+            • Total <code>{ai_slop_total_checks}</code>
             • Soul Over AI <code>{ai_slop_soul_over_ai}</code>
             • Spotify AI Blocker <code>{ai_slop_spotify_ai_blocker}</code>
             • SHLabs <code>{ai_slop_shlabs}</code>

--- a/src/telegram/actions/global_stats.rs
+++ b/src/telegram/actions/global_stats.rs
@@ -32,6 +32,10 @@ pub async fn handle(
         lyrics_musixmatch,
         lyrics_lrclib,
         lyrics_analyzed,
+        ai_slop_spotify_ai_blocker,
+        ai_slop_soul_over_ai,
+        ai_slop_shlabs,
+        ai_slop_human_made,
     } = UserService::get_stats(app.db(), None).await?;
 
     let user_locales = UserService::count_users_locales(app.db())
@@ -45,6 +49,14 @@ pub async fn handle(
         })
         .collect_vec()
         .join("\n");
+
+    let ai_slop_total =
+        ai_slop_spotify_ai_blocker + ai_slop_soul_over_ai + ai_slop_shlabs + ai_slop_human_made;
+    let ai_slop_spotify_ai_blocker_ratio =
+        100.0 * ai_slop_spotify_ai_blocker as f32 / ai_slop_total as f32;
+    let ai_slop_soul_over_ai_ratio = 100.0 * ai_slop_soul_over_ai as f32 / ai_slop_total as f32;
+    let ai_slop_shlabs_ratio = 100.0 * ai_slop_shlabs as f32 / ai_slop_total as f32;
+    let ai_slop_human_made_ratio = 100.0 * ai_slop_human_made as f32 / ai_slop_total as f32;
 
     let lyrics_found_ratio = 100.0 * lyrics_found as f32 / lyrics_checked as f32;
     let lyrics_genius_ratio = 100.0 * lyrics_genius as f32 / lyrics_found as f32;
@@ -104,6 +116,14 @@ pub async fn handle(
             <b>Locales stats</b>
 
             {user_locales}
+
+            <b>AI Slop Detection</b>
+
+            • Total <code>{ai_slop_total}</code>
+            • Soul Over AI <code>{ai_slop_soul_over_ai} ({ai_slop_soul_over_ai_ratio:.2}%)</code>
+            • Spotify AI Blocker <code>{ai_slop_spotify_ai_blocker} ({ai_slop_spotify_ai_blocker_ratio:.2}%)</code>
+            • SHLabs <code>{ai_slop_shlabs} ({ai_slop_shlabs_ratio:.2}%)</code>
+            • Human Made <code>{ai_slop_human_made} ({ai_slop_human_made_ratio:.2}%)</code>
 
             <blockquote expandable><b>Languages stats:</b>
 

--- a/src/telegram/actions/stats.rs
+++ b/src/telegram/actions/stats.rs
@@ -38,8 +38,13 @@ pub async fn handle(
         lyrics_checked,
         lyrics_profane,
         lyrics_analyzed,
+        ai_slop_spotify_ai_blocker,
+        ai_slop_soul_over_ai,
+        ai_slop_shlabs,
         ..
     } = UserService::get_stats(app.db(), Some(state.user_id())).await?;
+
+    let ai_slop_total = ai_slop_spotify_ai_blocker + ai_slop_soul_over_ai + ai_slop_shlabs;
 
     let all_langs = TrackLanguageStatsService::sum_for_user(app.db(), state.user_id()).await?;
 
@@ -72,6 +77,7 @@ pub async fn handle(
         lyrics_analyzed = lyrics_analyzed,
         ignored = ignored,
         lyrics_profane = lyrics_profane,
+        ai_slop_total = ai_slop_total,
         languages = languages,
     );
 


### PR DESCRIPTION
Track AI slop detection results per provider (Spotify AI Blocker, Soul Over AI, SHLabs, Human Made) with database counters, metrics collection for both InfluxDB and Prometheus, and display in user and global statistics views.